### PR TITLE
fix: model replace. dataclass to Pydantic

### DIFF
--- a/mycli/elasticache.py
+++ b/mycli/elasticache.py
@@ -1,79 +1,93 @@
 import click
 import json
-from src.offering_finder.models.elasticache_params import ElastiCacheParams
+from src.offering_finder.models.elasticache_params import (
+    ElastiCacheParams,
+    ElastiCachePurchaseParams,
+)
 from src.offering_finder.managers.elasticache_manager import ElastiCacheManager
 
 
 # elasticache subcommand
 @click.command()
 @click.option(
-    "--region_name",
-    required=True,
-    help="AWS region name (e.g., 'ap-northeast-1')"
+    "--purchase_profile",
+    required=False,
+    type=str,
+    help="Purchase command set a named profile (e.g., 'default' 'my-profile')",
 )
 @click.option(
-    "--quantity",
-    required=True,
-    type=int,
-    help="Quantity (e.g., 1)"
+    "--region_name", required=True, help="AWS region name (e.g., 'ap-northeast-1')"
 )
+@click.option("--quantity", required=True, type=int, help="Quantity (e.g., 1)")
 @click.option(
     "--cache_node_type",
     required=True,
+    type=str,
     help=(
         "Cache node type "
         "(e.g., 'cache.m5.large' 'cache.r5.xlarge' 'cache.t3.medium'...)"
-    )
+    ),
 )
 @click.option(
     "--duration",
     required=False,
-    help="Duration (e.g., 31536000 94608000)"
+    type=str,
+    help="Duration (e.g., '31536000' '94608000')",
 )
 @click.option(
     "--product_description",
     required=True,
+    type=str,
     help="Product description (e.g., 'redis oss' 'memcached' 'valkey')",
 )
 @click.option(
     "--offering_type",
     required=False,
-    help=(
-        "Offering type "
-        "(e.g., 'All Upfront', 'Partial Upfront', 'No Upfront')"
-    )
+    type=str,
+    help=("Offering type " "(e.g., 'All Upfront', 'Partial Upfront', 'No Upfront')"),
 )
 @click.option(
     "--reserved_cache_nodes_offering_id",
     required=False,
+    type=str,
     help="Reserved cache nodes offering ID (optional)",
 )
 @click.option(
     "--reserved_cache_node_id",
     required=False,
+    type=str,
     help="Reserved cache node ID (optional)",
 )
 def elasticache(
+    purchase_profile,
     region_name,
     quantity,
+    reserved_cache_node_id,
     reserved_cache_nodes_offering_id,
     cache_node_type,
     duration,
     product_description,
     offering_type,
-    reserved_cache_node_id,
 ):
-    """ Retrieve ElastiCache offerings """
-    params = ElastiCacheParams(
+    """Retrieve ElastiCache offerings"""
+    manager = ElastiCacheManager(region_name=region_name)
+    """ 1. Get all offerings """
+    offering_params = ElastiCacheParams(
+        CacheNodeType=cache_node_type,
+        Duration=duration,
+        ProductDescription=product_description,
+        OfferingType=offering_type,
+        ReservedCacheNodesOfferingId=reserved_cache_nodes_offering_id,
+    )
+    offerings = manager.get_offerings(offering_params)
+
+    """ 2. Add Purchase Command and Purchase Offering """
+    purchase_params = ElastiCachePurchaseParams(
+        purchase_profile=purchase_profile,
         region_name=region_name,
         quantity=quantity,
-        reserved_cache_nodes_offering_id=reserved_cache_nodes_offering_id,
-        cache_node_type=cache_node_type,
-        duration=duration,
-        product_description=product_description,
-        offering_type=offering_type,
         reserved_cache_node_id=reserved_cache_node_id,
     )
-    manager = ElastiCacheManager(region_name=region_name)
-    offerings = manager.get_offering_ids(params)
-    print(json.dumps(offerings, indent=2))
+    result = manager.add_keys_to_offerings(offerings, purchase_params)
+
+    print(json.dumps(result, indent=2))

--- a/mycli/opensearch.py
+++ b/mycli/opensearch.py
@@ -3,7 +3,7 @@ import json
 from src.offering_finder.models.opensearch_params import (
     OpenSearchParams,
     OpenSearchFilterParams,
-    OpenSearchPurchaseParams
+    OpenSearchPurchaseParams,
 )
 from src.offering_finder.managers.opensearch_manager import OpenSearchManager
 
@@ -11,10 +11,16 @@ from src.offering_finder.managers.opensearch_manager import OpenSearchManager
 # Opensearch subcommand
 @click.command()
 @click.option(
+    "--purchase_profile",
+    required=False,
+    type=str,
+    help="Purchase command set a named profile (e.g., 'default' 'my-profile')",
+)
+@click.option(
     "--region_name",
     required=True,
     type=str,
-    help="AWS region name (e.g., 'ap-northeast-1') (required)"
+    help="AWS region name (e.g., 'ap-northeast-1') (required)",
 )
 @click.option(
     "--instance_type",
@@ -23,31 +29,19 @@ from src.offering_finder.managers.opensearch_manager import OpenSearchManager
     help=(
         "Instance type "
         "(e.g., 'r5.large.search' 'm5.xlarge.search' 't3.medium.search'...)"
-    )
+    ),
 )
 @click.option(
-    "--duration",
-    required=False,
-    type=int,
-    help=(
-        "Duration (e.g., 31536000, 94608000)"
-    )
+    "--duration", required=False, type=int, help=("Duration (e.g., 31536000, 94608000)")
 )
 @click.option(
     "--payment_option",
     required=False,
     type=str,
-    help=(
-        "Offering type ('All_UPFRONT', 'PARTIAL_UPFRONT', 'NO_UPFRONT')"
-    )
+    help=("Offering type ('All_UPFRONT', 'PARTIAL_UPFRONT', 'NO_UPFRONT')"),
 )
 @click.option(
-    "--currency_code",
-    required=False,
-    type=str,
-    help=(
-        "Currency code ('USD' 'CNY')"
-    )
+    "--currency_code", required=False, type=str, help=("Currency code ('USD' 'CNY')")
 )
 @click.option(
     "--reserved_instance_offering_id",
@@ -55,15 +49,13 @@ from src.offering_finder.managers.opensearch_manager import OpenSearchManager
     type=str,
     help=(
         "ReservedInstanceOfferingId The ID of the Reserved Instance offering to purchase."
-    )
+    ),
 )
 @click.option(
     "--quantity",
     required=True,
     type=int,
-    help=(
-        "Quantity The number of OpenSearch instances to reserve. (e.g., 1)"
-    )
+    help=("Quantity The number of OpenSearch instances to reserve. (e.g., 1)"),
 )
 @click.option(
     "--reservation_name",
@@ -72,9 +64,10 @@ from src.offering_finder.managers.opensearch_manager import OpenSearchManager
     help=(
         "Reservation name A customer-specified identifier to track this reservation. "
         "(e.g., 'my-reservation') (optional)"
-    )
+    ),
 )
 def opensearch(
+    purchase_profile,
     region_name,
     reserved_instance_offering_id,
     instance_type,
@@ -82,28 +75,30 @@ def opensearch(
     currency_code,
     payment_option,
     quantity,
-    reservation_name
+    reservation_name,
 ):
-    """ Retrieve OpenSearch offerings """
+    print(purchase_profile)
+    """Retrieve OpenSearch offerings"""
     """ 1. Get all offerings """
     params_all = OpenSearchParams(
-        reserved_instance_offering_id=reserved_instance_offering_id,
+        ReservedInstanceOfferingId=reserved_instance_offering_id,
     )
     manager = OpenSearchManager(region_name=region_name)
     all_offerings = manager.get_offering_ids(params_all)
 
     """ 2. Filter offerings to match the specified criteria """
     filter_params = OpenSearchFilterParams(
-        reserved_instance_offering_id=reserved_instance_offering_id,
-        instance_type=instance_type,
-        duration=duration,
-        currency_code=currency_code,
-        payment_option=payment_option,
+        ReservedInstanceOfferingId=reserved_instance_offering_id,
+        InstanceType=instance_type,
+        Duration=duration,
+        CurrencyCode=currency_code,
+        PaymentOption=payment_option,
     )
     filter_offerings = manager.filter_offerings(all_offerings, filter_params)
 
     """ 3. Add Purchase Command and Purchase Offering """
     purchase_params = OpenSearchPurchaseParams(
+        purchase_profile=purchase_profile,
         region_name=region_name,
         quantity=quantity,
         reservation_name=reservation_name,

--- a/mycli/rds.py
+++ b/mycli/rds.py
@@ -1,54 +1,64 @@
 import click
 import json
-from src.offering_finder.models.rds_params import RDSParams
+from src.offering_finder.models.rds_params import RDSParams, RDSPurchaseParams
 from src.offering_finder.managers.rds_manager import RDSManager
 
 
 # rds subcommand
 @click.command()
 @click.option(
+    "--purchase_profile",
+    required=False,
+    type=str,
+    help="Purchase command set a named profile (e.g., 'default' 'my-profile')",
+)
+@click.option(
+    "--reserved_instance_offering_id",
+    required=False,
+    type=str,
+    help="Reserved instance offering ID",
+)
+@click.option(
     "--product_description",
     required=True,
-    help="Product description (e.g., 'MySQL' 'PostgreSQL' 'aurora mysql' 'aurora postgresql')"
+    type=str,
+    help="Product description (e.g., 'MySQL' 'PostgreSQL' 'aurora mysql' 'aurora postgresql')",
 )
 @click.option(
     "--db_instance_class",
     required=True,
-    help="DB instance class (e.g., 'db.m5.large' 'db.r5.xlarge' 'db.t3.medium'...)"
+    type=str,
+    help="DB instance class (e.g., 'db.m5.large' 'db.r5.xlarge' 'db.t3.medium'...)",
 )
 @click.option(
-    "--duration",
-    required=True,
-    help="Duration (e.g., 31536000)"
+    "--duration", required=True, type=str, help="Duration (e.g., '31536000' '94608000')"
 )
-@click.option(
-    "--quantity",
-    required=True,
-    type=int,
-    help="Quantity (e.g., 2)"
-)
+@click.option("--quantity", required=True, type=int, help="Quantity (e.g., 2)")
 @click.option(
     "--region_name",
     required=True,
-    help="AWS region name (e.g., 'ap-northeast-1')"
+    type=str,
+    help="AWS region name (e.g., 'ap-northeast-1')",
 )
 @click.option(
-    "--multi_az",
-    is_flag=True,
-    help="Specify if the instance should be Multi-AZ"
+    "--multi_az", is_flag=True, help="Specify if the instance should be Multi-AZ"
 )
 @click.option(
     "--offering_type",
     required=True,
+    type=str,
     help="Offering type (e.g., 'All Upfront', 'Partial Upfront', 'No Upfront')",
 )
 @click.option(
     "--reserved_instance_id",
     required=False,
+    type=str,
     help="Reserved instance ID (optional)",
 )
 def rds(
+    purchase_profile,
     region_name,
+    reserved_instance_offering_id,
     quantity,
     product_description,
     db_instance_class,
@@ -57,16 +67,26 @@ def rds(
     offering_type,
     reserved_instance_id,
 ):
-    """ Retrieve Amazon RDS offerings """
+    """Retrieve Amazon RDS offerings"""
+    manager = RDSManager(region_name=region_name)
+    """ 1. Get all offerings """
     params = RDSParams(
-        product_description=product_description,
-        db_instance_class=db_instance_class,
-        duration=duration,
+        ReservedDBInstanceOfferingId=reserved_instance_offering_id,
+        ProductDescription=product_description,
+        DBInstanceClass=db_instance_class,
+        Duration=duration,
+        MultiAZ=multi_az,
+        OfferingType=offering_type,
+    )
+    offerings = manager.get_offerings(params)
+
+    """ 2. Add Purchase Command and Purchase Offering """
+    purchase_params = RDSPurchaseParams(
+        purchase_profile=purchase_profile,
+        region_name=region_name,
         quantity=quantity,
-        multi_az=multi_az,
-        offering_type=offering_type,
         reserved_instance_id=reserved_instance_id,
     )
-    manager = RDSManager(region_name=region_name)
-    offerings = manager.get_offering_ids(params)
-    print(json.dumps(offerings, indent=2))
+    result = manager.add_keys_to_offerings(offerings, purchase_params)
+
+    print(json.dumps(result, indent=2))

--- a/mycli/savingsplans.py
+++ b/mycli/savingsplans.py
@@ -1,45 +1,33 @@
 import click
 import json
-from src.offering_finder.models.savingsplans_params import SavingsPlansParams
+from src.offering_finder.models.savingsplans_params import (
+    SavingsPlansParams,
+    SavingsPlansPurchaseParams,
+)
 from src.offering_finder.managers.savingsplans_manager import SavingsPlansManager
 
 
 # savingsplans subcommand
 @click.command()
 @click.option(
+    "--purchase_profile",
+    required=False,
+    type=str,
+    help="Purchase command set a named profile (e.g., 'default' 'my-profile')",
+)
+@click.option(
     "--region_name",
     default="ap-northeast-1",
     required=True,
     type=str,
-    help="AWS region name (e.g., 'ap-northeast-1')"
-)
-@click.option(
-    "--commitment",
-    default=0.01,
-    type=float,
-    required=True,
-    help="Commitment (e.g., 0.01)"
-)
-@click.option(
-    "--durations",
-    default=[31536000],
-    multiple=True,
-    type=int,
-    help="Durations in seconds (e.g., 31536000 94608000)"
-)
-@click.option(
-    "--plan_types",
-    default=["Compute"],
-    required=False,
-    multiple=True,
-    type=str,
-    help="Plan type (e.g., 'Compute' 'EC2 Instance' 'EC2 Instance Family' 'Compute Instance' 'EC2 Instance Savings Plan')"
+    help="AWS region name (e.g., 'ap-northeast-1')",
 )
 @click.option(
     "--offering_id",
     required=False,
+    multiple=True,
     type=str,
-    help="Offering ID"
+    help="The IDs of the offerings.",
 )
 @click.option(
     "--payment_options",
@@ -47,33 +35,84 @@ from src.offering_finder.managers.savingsplans_manager import SavingsPlansManage
     required=False,
     multiple=True,
     type=str,
-    help="Offering type (e.g., 'All Upfront', 'Partial Upfront', 'No Upfront')"
+    help="Offering type (e.g., 'All Upfront', 'Partial Upfront', 'No Upfront')",
 )
 @click.option(
-    "--client_token",
+    "--product_type",
     required=False,
     type=str,
-    help="Client token"
+    help="Offering type ('EC2'|'Fargate'|'Lambda'|'SageMaker')",
 )
+@click.option(
+    "--plan_types",
+    default=["Compute"],
+    required=False,
+    multiple=True,
+    type=str,
+    help="Plan type ('Compute'|'EC2Instance'|'SageMaker')",
+)
+@click.option(
+    "--commitment",
+    default=0.01,
+    type=float,
+    required=True,
+    help="Commitment (e.g., 0.01)",
+)
+@click.option(
+    "--currency",
+    type=str,
+    required=False,
+    help="currency ('CNY'|'USD')",
+)
+@click.option(
+    "--durations",
+    default=[31536000],
+    multiple=True,
+    required=True,
+    type=int,
+    help="Durations in seconds ( 31536000 | 94608000 )",
+)
+@click.option(
+    "--purchase_time",
+    required=False,
+    type=str,
+    help="The purchase time of the Savings Plan in UTC format (YYYY-MM-DDTHH:MM:SSZ).",
+)
+@click.option("--client_token", required=False, type=str, help="Client token")
 def savingsplans(
+    purchase_profile,
     region_name,
     commitment,
     durations,
     plan_types,
+    product_type,
     offering_id,
     payment_options,
     client_token,
+    currency,
+    purchase_time,
 ):
-    """ Retrieve SavingsPlans offerings """
-    params = SavingsPlansParams(
-        region_name=region_name,
-        commitment=commitment,
-        offering_id=offering_id,
-        durations=durations,
-        plan_types=plan_types,
-        payment_options=payment_options,
-        client_token=client_token,
-    )
+    """Retrieve SavingsPlans offerings"""
     manager = SavingsPlansManager(region_name=region_name)
-    offerings = manager.get_offering_ids(params)
-    print(json.dumps(offerings, indent=2))
+    """ 1. Get all offerings """
+    params = SavingsPlansParams(
+        offeringIds=offering_id,
+        paymentOptions=payment_options,
+        durations=durations,
+        planTypes=plan_types,
+        productType=product_type,
+        currencies=currency,
+    )
+    offerings = manager.get_offerings(params)
+
+    """ 2. Add Purchase Command and Purchase Offering """
+    purchase_params = SavingsPlansPurchaseParams(
+        purchase_profile=purchase_profile,
+        region_name=region_name,
+        commitment=float(commitment),
+        client_token=client_token,
+        purchase_time=purchase_time,
+    )
+    result = manager.add_keys_to_offerings(offerings, purchase_params)
+
+    print(json.dumps(result, indent=2))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.13"
 dependencies = [
     "boto3>=1.35.69",
     "click>=8.1.7",
+    "pydantic>=2.10.5",
     "pytest>=8.3.4",
 ]
 

--- a/src/offering_finder/managers/elasticache_manager.py
+++ b/src/offering_finder/managers/elasticache_manager.py
@@ -3,26 +3,30 @@ import logging
 from typing import Any, Dict, List, Optional
 import boto3
 from offering_finder.clients.AWSClient import AWSClient
-from offering_finder.models.elasticache_params import ElastiCacheParams
+from offering_finder.models.elasticache_params import (
+    ElastiCacheParams,
+    ElastiCachePurchaseParams,
+)
 
 
 class ElastiCacheManager:
-    def __init__(
-        self,
-        region_name: str
-    ) -> None:
-        self.client = AWSClient("elasticache",region_name)
+    def __init__(self, region_name: str) -> None:
+        self.client = AWSClient("elasticache", region_name)
 
     def generate_purchase_command(
         self,
-        offering_id: str,
+        purchase_profile: Optional[str],
         region_name: str,
+        offering_id: str,
         quantity: int,
-        reserved_cache_node_id: Optional[str] = None
+        reserved_cache_node_id: Optional[str] = None,
     ) -> str:
         """
         Generate the AWS CLI command to purchase a reserved cache node offering.
         """
+        command = ""
+        if purchase_profile:
+            command += f"AWS_PROFILE={purchase_profile} "
         command = (
             f"aws elasticache purchase-reserved-cache-nodes-offering "
             f"--region {region_name} "
@@ -33,46 +37,45 @@ class ElastiCacheManager:
             command += f" --reserved-cache-node-id {reserved_cache_node_id}"
         return command
 
-    def add_keys_to_offering(
-            self,
-            offering: Dict[str, Any],
-            params: ElastiCacheParams
+    def add_keys_to_offerings(
+        self, offerings: Dict[str, Any], params: ElastiCachePurchaseParams
     ) -> Dict[str, Any]:
-        try:
-            if params.quantity:
+        result = []
+        for offering in offerings:
+            try:
                 offering["OrderQuantity"] = params.quantity
-                offering["OrderEstimatedAmount"] = float(offering["FixedPrice"]) * params.quantity
-            offering["Timestamp"] = datetime.datetime.now(datetime.timezone.utc).isoformat()
-            offering["PurchaseCommand"] = self.generate_purchase_command(
-                offering["ReservedCacheNodesOfferingId"],
-                params.region_name,
-                params.quantity,
-                params.reserved_cache_node_id,
-            )
-            return offering
-        except KeyError as e:
-            logging.error(f"Key error: {e}")
-        except ValueError as e:
-            logging.error(f"Value error: {e}")
-        except Exception as e:
-            logging.error(f"An unexpected error occurred: {e}")
-        return offering
+                offering["OrderEstimatedAmount"] = (
+                    float(offering["FixedPrice"]) * params.quantity
+                )
+                offering["Timestamp"] = datetime.datetime.now(
+                    datetime.timezone.utc
+                ).isoformat()
+                offering["PurchaseCommand"] = self.generate_purchase_command(
+                    purchase_profile=params.purchase_profile,
+                    region_name=params.region_name,
+                    offering_id=offering["ReservedCacheNodesOfferingId"],
+                    quantity=params.quantity,
+                    reserved_cache_node_id=params.reserved_cache_node_id,
+                )
+                result.append(offering)
+            except KeyError as e:
+                logging.error(f"Key error: {e}")
+            except ValueError as e:
+                logging.error(f"Value error: {e}")
+            except Exception as e:
+                logging.error(f"An unexpected error occurred: {e}")
+        return result
 
-    def get_offering_ids(
-            self,
-            params: ElastiCacheParams
-    ) -> List[Dict[str, Any]]:
+    def get_offerings(self, params: ElastiCacheParams) -> List[Dict[str, Any]]:
         try:
-            aws_params = params.to_dict()
+            fetch_params = params.model_dump(exclude_none=True)
             result = []
             while True:
-                response = self.client.describe_offerings(aws_params)
+                response = self.client.describe_offerings(fetch_params)
                 offerings = response.get("ReservedCacheNodesOfferings", [])
-                for offering in offerings:
-                    offering = self.add_keys_to_offering(offering, params)
                 result.extend(offerings)
                 if "Marker" in response:
-                    aws_params["Marker"] = response["Marker"]
+                    fetch_params["Marker"] = response["Marker"]
                 else:
                     break
             return result

--- a/src/offering_finder/managers/rds_manager.py
+++ b/src/offering_finder/managers/rds_manager.py
@@ -3,7 +3,7 @@ import logging
 from typing import Any, Dict, List, Optional
 import boto3
 from offering_finder.clients.AWSClient import AWSClient
-from offering_finder.models.rds_params import RDSParams
+from offering_finder.models.rds_params import RDSParams, RDSPurchaseParams
 
 
 class RDSManager:
@@ -12,6 +12,7 @@ class RDSManager:
 
     def generate_purchase_command(
         self,
+        purchase_profile: Optional[str],
         offering_id: str,
         region_name: str,
         quantity: int,
@@ -20,7 +21,10 @@ class RDSManager:
         """
         Generate the AWS CLI command to purchase a reserved DB instance offering.
         """
-        command = (
+        command = ""
+        if purchase_profile:
+            command += f"AWS_PROFILE={purchase_profile} "
+        command += (
             f"aws rds purchase-reserved-db-instances-offering "
             f"--region {region_name} "
             f"--reserved-db-instances-offering-id {offering_id} "
@@ -30,45 +34,45 @@ class RDSManager:
             command += f" --reserved-db-instance-id {reserved_instance_id}"
         return command
 
-    def add_keys_to_offering(
-        self, offering: Dict[str, Any], params: RDSParams
+    def add_keys_to_offerings(
+        self, offerings: Dict[str, Any], params: RDSPurchaseParams
     ) -> Dict[str, Any]:
-        try:
-            if params.quantity:
+        result = []
+        for offering in offerings:
+            try:
                 offering["OrderQuantity"] = params.quantity
                 offering["OrderEstimatedAmount"] = (
                     float(offering["FixedPrice"]) * params.quantity
                 )
-            offering["Timestamp"] = datetime.datetime.now(
-                datetime.timezone.utc
-            ).isoformat()
-            offering["PurchaseCommand"] = self.generate_purchase_command(
-                offering["ReservedDBInstancesOfferingId"],
-                params.region_name,
-                params.quantity,
-                params.reserved_instance_id,
-            )
-            return offering
-        except KeyError as e:
-            logging.error(f"Key error: {e}")
-        except ValueError as e:
-            logging.error(f"Value error: {e}")
-        except Exception as e:
-            logging.error(f"An unexpected error occurred: {e}")
-        return offering
+                offering["Timestamp"] = datetime.datetime.now(
+                    datetime.timezone.utc
+                ).isoformat()
+                offering["PurchaseCommand"] = self.generate_purchase_command(
+                    purchase_profile=params.purchase_profile,
+                    region_name=params.region_name,
+                    offering_id=offering["ReservedDBInstancesOfferingId"],
+                    quantity=params.quantity,
+                    reserved_instance_id=params.reserved_instance_id,
+                )
+                result.append(offering)
+            except KeyError as e:
+                logging.error(f"Key error: {e}")
+            except ValueError as e:
+                logging.error(f"Value error: {e}")
+            except Exception as e:
+                logging.error(f"An unexpected error occurred: {e}")
+            return result
 
-    def get_offering_ids(self, params: RDSParams) -> List[Dict[str, Any]]:
+    def get_offerings(self, params: RDSParams) -> List[Dict[str, Any]]:
         try:
-            aws_params = params.to_dict()
+            rds_params = params.model_dump(exclude_none=True)
             result = []
             while True:
-                response = self.client.describe_offerings(aws_params)
+                response = self.client.describe_offerings(rds_params)
                 offerings = response.get("ReservedDBInstancesOfferings", [])
-                for offering in offerings:
-                    offering = self.add_keys_to_offering(offering, params)
                 result.extend(offerings)
                 if "Marker" in response:
-                    aws_params["Marker"] = response["Marker"]
+                    rds_params["Marker"] = response["Marker"]
                 else:
                     break
             return result

--- a/src/offering_finder/managers/rds_manager.py
+++ b/src/offering_finder/managers/rds_manager.py
@@ -7,18 +7,15 @@ from offering_finder.models.rds_params import RDSParams
 
 
 class RDSManager:
-    def __init__(
-        self,
-        region_name: str
-    ) -> None:
-        self.client = AWSClient("rds",region_name)
+    def __init__(self, region_name: str) -> None:
+        self.client = AWSClient("rds", region_name)
 
     def generate_purchase_command(
         self,
         offering_id: str,
         region_name: str,
         quantity: int,
-        reserved_instance_id: Optional[str] = None
+        reserved_instance_id: Optional[str] = None,
     ) -> str:
         """
         Generate the AWS CLI command to purchase a reserved DB instance offering.
@@ -34,15 +31,17 @@ class RDSManager:
         return command
 
     def add_keys_to_offering(
-            self,
-            offering: Dict[str, Any],
-            params: RDSParams
+        self, offering: Dict[str, Any], params: RDSParams
     ) -> Dict[str, Any]:
         try:
             if params.quantity:
                 offering["OrderQuantity"] = params.quantity
-                offering["OrderEstimatedAmount"] = float(offering["FixedPrice"]) * params.quantity
-            offering["Timestamp"] = datetime.datetime.now(datetime.timezone.utc).isoformat()
+                offering["OrderEstimatedAmount"] = (
+                    float(offering["FixedPrice"]) * params.quantity
+                )
+            offering["Timestamp"] = datetime.datetime.now(
+                datetime.timezone.utc
+            ).isoformat()
             offering["PurchaseCommand"] = self.generate_purchase_command(
                 offering["ReservedDBInstancesOfferingId"],
                 params.region_name,
@@ -58,10 +57,7 @@ class RDSManager:
             logging.error(f"An unexpected error occurred: {e}")
         return offering
 
-    def get_offering_ids(
-            self,
-            params: RDSParams
-    ) -> List[Dict[str, Any]]:
+    def get_offering_ids(self, params: RDSParams) -> List[Dict[str, Any]]:
         try:
             aws_params = params.to_dict()
             result = []

--- a/src/offering_finder/managers/savingsplans_manager.py
+++ b/src/offering_finder/managers/savingsplans_manager.py
@@ -3,76 +3,88 @@ import logging
 from typing import Any, Dict, List, Optional
 import boto3
 from offering_finder.clients.AWSClient import AWSClient
-from offering_finder.models.savingsplans_params import SavingsPlansParams
+from offering_finder.models.savingsplans_params import (
+    SavingsPlansParams,
+    SavingsPlansPurchaseParams,
+)
 
 
 class SavingsPlansManager:
-    def __init__(
-        self,
-        region_name: str
-    ) -> None:
+    def __init__(self, region_name: str) -> None:
         self.client = AWSClient("savingsplans", region_name)
 
     def generate_purchase_command(
         self,
-        offering_id: str,
+        purchase_profile: Optional[str],
         region_name: str,
+        offering_id: str,
         commitment: int,
-        client_token: Optional[str] = None
+        purchase_time: Optional[str] = None,
+        client_token: Optional[str] = None,
+        tags: Optional[List[Dict[str, str]]] = None,
     ) -> str:
         """
         Generate the AWS CLI command to purchase a reserved cache node offering.
         """
-        command = (
-            f"aws savingsplans create-savings-plan "
-            f"--region {region_name} "
-            f"--savings-plan-offering-id {offering_id} "
-            f"--commitment {commitment}"
+        command = ""
+        if purchase_profile:
+            command += f"AWS_PROFILE={purchase_profile} "
+        command += (
+            f"aws savingsplans create-savings-plan"
+            f" --region {region_name}"
+            f" --savings-plan-offering-id {offering_id}"
+            f" --commitment {commitment}"
         )
+        if purchase_time:
+            command += f" --purchase-time {purchase_time}"
         if client_token:
             command += f" --client-token {client_token}"
+        if tags:
+            for tag in tags:
+                command += f" --tags Key={tag['Key']},Value={tag['Value']}"
         return command
 
-    def add_keys_to_offering(
-            self,
-            offering: Dict[str, Any],
-            params: SavingsPlansParams
+    def add_keys_to_offerings(
+        self, offerings: Dict[str, Any], params: SavingsPlansPurchaseParams
     ) -> Dict[str, Any]:
-        try:
-            if params.commitment:
+        result = []
+        for offering in offerings:
+            try:
                 offering["OrderCommitment"] = params.commitment
-                offering["OrderEstimatedAmount"] = float(offering["durationSeconds"]) * params.commitment
-            offering["Timestamp"] = datetime.datetime.now(datetime.timezone.utc).isoformat()
-            offering["PurchaseCommand"] = self.generate_purchase_command(
-                offering["offeringId"],
-                params.region_name,
-                params.commitment,
-                params.client_token,
-            )
-            return offering
-        except KeyError as e:
-            logging.error(f"Key error: {e}")
-        except ValueError as e:
-            logging.error(f"Value error: {e}")
-        except Exception as e:
-            logging.error(f"An unexpected error occurred: {e}")
+                offering["OrderEstimatedAmount"] = (
+                    float(offering["durationSeconds"]) * params.commitment
+                )
+                offering["Timestamp"] = datetime.datetime.now(
+                    datetime.timezone.utc
+                ).isoformat()
+                offering["PurchaseCommand"] = self.generate_purchase_command(
+                    offering_id=offering["offeringId"],
+                    purchase_profile=params.purchase_profile,
+                    region_name=params.region_name,
+                    commitment=params.commitment,
+                    client_token=params.client_token,
+                    purchase_time=params.purchase_time,
+                    tags=params.tags,
+                )
+                result.append(offering)
+            except KeyError as e:
+                logging.error(f"Key error: {e}")
+            except ValueError as e:
+                logging.error(f"Value error: {e}")
+            except Exception as e:
+                logging.error(f"An unexpected error occurred: {e}")
         return offering
 
-    def get_offering_ids(
-            self,
-            params: SavingsPlansParams
-    ) -> List[Dict[str, Any]]:
+    def get_offerings(self, params: SavingsPlansParams) -> List[Dict[str, Any]]:
         try:
-            aws_params = params.to_dict()
+            aws_params = params.model_dump(exclude_none=True)
             result = []
             while True:
                 response = self.client.describe_offerings(aws_params)
                 offerings = response.get("searchResults", [])
-                for offering in offerings:
-                    offering = self.add_keys_to_offering(offering, params)
                 result.extend(offerings)
                 if response.get("nextToken"):
-                    """ 次ページが無い場合も 'nextToken': '' という形で返ってくるため、空文字ではない事をチェックする"""
+                    """ 次ページが無い場合も 'nextToken': '' という形で返ってくるため、空文字ではない事をチェック"""
                     aws_params["nextToken"] = response["nextToken"]
                 else:
                     break

--- a/src/offering_finder/models/elasticache_params.py
+++ b/src/offering_finder/models/elasticache_params.py
@@ -1,41 +1,29 @@
-from dataclasses import dataclass
-from typing import Optional, Dict, Any
+from typing import Optional
+from pydantic import BaseModel
 
 
-@dataclass
-class ElastiCacheParams:
+class ElastiCachePurchaseParams(BaseModel):
     """
-    Data class for ElastiCache parameters.
-    https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_DescribeReservedCacheNodes.html
+    Data class for common parameters.
+    https://awscli.amazonaws.com/v2/documentation/api/latest/reference/elasticache/purchase-reserved-cache-nodes-offering.html
     """
-    region_name: Optional[str] = "ap-northeast-1"
+
+    purchase_profile: Optional[str] = None
+    region_name: Optional[str] = None
     quantity: Optional[int] = 1
-    marker: Optional[str] = None
-    reserved_cache_nodes_offering_id: Optional[str] = None
-    cache_node_type: Optional[str] = None
-    duration: Optional[str] = '31536000'
-    product_description: Optional[str] = None
-    offering_type: Optional[str] = 'All Upfront'
-    max_records: Optional[int] = 100
     reserved_cache_node_id: Optional[str] = None
 
-    def to_dict(self) -> Dict[str, Any]:
-        """
-        Converts the parameters to a dictionary for AWS API calls.
-        """
-        params = {}
-        if self.reserved_cache_nodes_offering_id:
-            params["ReservedCacheNodesOfferingId"] = self.reserved_cache_nodes_offering_id
-        if self.cache_node_type:
-            params["CacheNodeType"] = self.cache_node_type
-        if self.duration:
-            params["Duration"] = self.duration
-        if self.product_description:
-            params["ProductDescription"] = self.product_description
-        if self.offering_type:
-            params["OfferingType"] = self.offering_type
-        if self.max_records:
-            params["MaxRecords"] = self.max_records
-        if self.marker:
-            params["Marker"] = self.marker
-        return params
+
+class ElastiCacheParams(BaseModel):
+    """
+    Data class for ElastiCache parameters.
+    https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/elasticache/client/describe_reserved_cache_nodes_offerings.html
+    """
+
+    ReservedCacheNodesOfferingId: Optional[str] = None
+    CacheNodeType: Optional[str] = None
+    Duration: Optional[str] = "31536000"
+    ProductDescription: Optional[str] = None
+    OfferingType: Optional[str] = "All Upfront"
+    MaxRecords: Optional[int] = 100
+    Marker: Optional[str] = None

--- a/src/offering_finder/models/opensearch_params.py
+++ b/src/offering_finder/models/opensearch_params.py
@@ -10,7 +10,7 @@ class OpenSearchPurchaseParams(BaseModel):
     """
 
     region_name: Optional[str] = None
-    quantity: Optional[int] = None
+    quantity: Optional[int] = 1
     reservation_name: Optional[str] = None
     purchase_profile: Optional[str] = None
 
@@ -34,6 +34,6 @@ class OpenSearchFilterParams(BaseModel):
 
     ReservedInstanceOfferingId: Optional[str] = None
     InstanceType: Optional[str] = None
-    Duration: Optional[int] = None
-    CurrencyCode: Optional[str] = None
+    Duration: Optional[int] = 31536000
+    CurrencyCode: Optional[str] = "USD"
     PaymentOption: Optional[str] = None

--- a/src/offering_finder/models/opensearch_params.py
+++ b/src/offering_finder/models/opensearch_params.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 class OpenSearchPurchaseParams(BaseModel):
     """
     Data class for common parameters.
-    https://docs.aws.amazon.com/cli/latest/reference/opensearch/purchase-reserved-instance-offering.html
+    https://awscli.amazonaws.com/v2/documentation/api/latest/reference/opensearch/purchase-reserved-instance-offering.html
     """
 
     region_name: Optional[str] = None

--- a/src/offering_finder/models/opensearch_params.py
+++ b/src/offering_finder/models/opensearch_params.py
@@ -1,49 +1,39 @@
-from dataclasses import dataclass
-from typing import Optional, Dict, Any
+from typing import Optional
+
+from pydantic import BaseModel
 
 
-@dataclass
-class OpenSearchPurchaseParams:
+class OpenSearchPurchaseParams(BaseModel):
     """
     Data class for common parameters.
+    https://docs.aws.amazon.com/cli/latest/reference/opensearch/purchase-reserved-instance-offering.html
     """
-    region_name: Optional[str] = "ap-northeast-1"
-    quantity: Optional[int] = 1
+
+    region_name: Optional[str] = None
+    quantity: Optional[int] = None
     reservation_name: Optional[str] = None
+    purchase_profile: Optional[str] = None
 
 
-@dataclass
-class OpenSearchParams:
+class OpenSearchParams(BaseModel):
     """
     Data class for OpenSearch reserved instance offerings parameters.
     https://boto3.amazonaws.com/v1/documentation/api/1.35.8/reference/services/opensearch/client/describe_reserved_instance_offerings.html
     """
-    reserved_instance_offering_id: Optional[str] = None
-    max_results: Optional[int] = 100
-    next_token: Optional[str] = None
 
-    def to_dict(self) -> Dict[str, Any]:
-        """
-        Converts the parameters to a dictionary for AWS API calls.
-        """
-        params = {}
-        if self.reserved_instance_offering_id:
-            params["ReservedInstanceOfferingId"] = self.reserved_instance_offering_id
-        if self.max_results:
-            params["MaxResults"] = self.max_results
-        if self.next_token:
-            params["NextToken"] = self.next_token
-        return params
+    ReservedInstanceOfferingId: Optional[str] = None
+    MaxResults: Optional[int] = 100
+    NextToken: Optional[str] = None
 
 
-@dataclass
-class OpenSearchFilterParams:
+class OpenSearchFilterParams(BaseModel):
     """
     Data class for OpenSearch reserved instance offerings filter parameters.
     https://boto3.amazonaws.com/v1/documentation/api/1.35.8/reference/services/opensearch/client/describe_reserved_instance_offerings.html
     """
-    reserved_instance_offering_id: Optional[str] = None
-    instance_type: Optional[str] = None
-    duration: Optional[int] = None
-    currency_code: Optional[str] = None
-    payment_option: Optional[str] = None
+
+    ReservedInstanceOfferingId: Optional[str] = None
+    InstanceType: Optional[str] = None
+    Duration: Optional[int] = None
+    CurrencyCode: Optional[str] = None
+    PaymentOption: Optional[str] = None

--- a/src/offering_finder/models/rds_params.py
+++ b/src/offering_finder/models/rds_params.py
@@ -20,7 +20,7 @@ class RDSParams(BaseModel):
     https://boto3.amazonaws.com/v1/documentation/api/1.35.6/reference/services/rds/client/describe_reserved_db_instances_offerings.html
     """
 
-    ReservedDBInstancesOfferingId: Optional[str] = None
+    ReservedDBInstanceOfferingId: Optional[str] = None
     DBInstanceClass: Optional[str] = None
     Duration: Optional[str] = "31536000"
     ProductDescription: Optional[str] = None

--- a/src/offering_finder/models/rds_params.py
+++ b/src/offering_finder/models/rds_params.py
@@ -1,50 +1,31 @@
-from dataclasses import dataclass
-from typing import Optional, Dict, Any
+from typing import Optional, Any, Dict
+from pydantic import BaseModel
 
 
-@dataclass
-class RDSParams:
+class RDSPurchaseParams(BaseModel):
     """
-    Data class for RDS parameters.
-    https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DescribeReservedDBInstances.html
+    Data class for common parameters.
+    https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/purchase-reserved-db-instances-offering.html
     """
-    region_name: Optional[str] = "ap-northeast-1"
-    quantity: Optional[int] = None
-    marker: Optional[str] = None
-    reserved_db_instance_id: Optional[str] = None
-    reserved_db_instances_offering_id: Optional[str] = None
-    db_instance_class: Optional[str] = None
-    duration: Optional[str] = None
-    offering_type: Optional[str] = None
-    multi_az: Optional[bool] = None
-    product_description: Optional[str] = None
-    filters: Optional[list[Dict[str, Any]]] = None
-    max_records: Optional[int] = 100
+
+    purchase_profile: Optional[str] = None
+    region_name: Optional[str] = None
+    quantity: Optional[int] = 1
     reserved_instance_id: Optional[str] = None
 
-    def to_dict(self) -> Dict[str, Any]:
-        """
-        Converts the parameters to a dictionary for AWS API calls.
-        """
-        params = {}
-        if self.reserved_db_instance_id:
-            params["ReservedDBInstanceId"] = self.reserved_db_instance_id
-        if self.reserved_db_instances_offering_id:
-            params["ReservedDBInstancesOfferingId"] = self.reserved_db_instances_offering_id
-        if self.db_instance_class:
-            params["DBInstanceClass"] = self.db_instance_class
-        if self.duration:
-            params["Duration"] = self.duration
-        if self.offering_type:
-            params["OfferingType"] = self.offering_type
-        if self.multi_az is not None:
-            params["MultiAZ"] = self.multi_az
-        if self.product_description:
-            params["ProductDescription"] = self.product_description
-        if self.filters:
-            params["Filters"] = self.filters
-        if self.max_records:
-            params["MaxRecords"] = self.max_records
-        if self.marker:
-            params["Marker"] = self.marker
-        return params
+
+class RDSParams(BaseModel):
+    """
+    Data class for RDS parameters.
+    https://boto3.amazonaws.com/v1/documentation/api/1.35.6/reference/services/rds/client/describe_reserved_db_instances_offerings.html
+    """
+
+    ReservedDBInstancesOfferingId: Optional[str] = None
+    DBInstanceClass: Optional[str] = None
+    Duration: Optional[str] = "31536000"
+    ProductDescription: Optional[str] = None
+    MultiAZ: Optional[bool] = False
+    OfferingType: Optional[str] = None
+    MaxRecords: Optional[int] = 100
+    Marker: Optional[str] = None
+    Filters: Optional[list[Dict[str, Any]]] = None

--- a/src/offering_finder/models/savingsplans_params.py
+++ b/src/offering_finder/models/savingsplans_params.py
@@ -1,51 +1,38 @@
-from dataclasses import dataclass, field
-from typing import Optional, List, Dict, Any
+from typing import Optional, Any, Dict, List
+from pydantic import BaseModel
 
 
-@dataclass
-class SavingsPlansParams:
+class SavingsPlansPurchaseParams(BaseModel):
+    """
+    Data class for common parameters.
+    https://awscli.amazonaws.com/v2/documentation/api/latest/reference/savingsplans/create-savings-plan.html
+    """
+
+    purchase_profile: Optional[str] = None
+    region_name: Optional[str] = None
+    offering_id: Optional[str] = None
+    commitment: Optional[float] = 0.0
+    purchase_time: Optional[str] = None
+    client_token: Optional[str] = None
+    tags: Optional[List[Dict[str, str]]] = None
+
+
+class SavingsPlansParams(BaseModel):
     """
     Data class for Savings Plans parameters.
     https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/savingsplans/client/describe_savings_plans_offerings.html
     """
-    region_name: Optional[str] = "ap-northeast-1"
-    commitment: Optional[int] = None
-    offering_id: Optional[str] = None
-    client_token: Optional[str] = None
-    payment_options: Optional[List[str]] = field(default_factory=list)
-    plan_types: Optional[List[str]] = field(default_factory=list)
-    durations: Optional[List[int]] = field(default_factory=list)
-    currencies: Optional[List[str]] = field(default_factory=list)
-    descriptions: Optional[List[str]] = field(default_factory=list)
-    service_codes: Optional[List[str]] = field(default_factory=list)
-    usage_types: Optional[List[str]] = field(default_factory=list)
-    operations: Optional[List[str]] = field(default_factory=list)
-    filters: Optional[List[Dict[str, Any]]] = field(default_factory=list)
-    max_results: Optional[int] = 100
 
-    def to_dict(self) -> Dict[str, Any]:
-        """
-        Converts the parameters to a dictionary for AWS API calls,
-        """
-        params = {}
-        if self.payment_options:
-            params["paymentOptions"] = self.payment_options
-        if self.plan_types:
-            params["planTypes"] = self.plan_types
-        if self.durations:
-            params["durations"] = self.durations
-        if self.currencies:
-            params["currencies"] = self.currencies
-        if self.currencies:
-            params["descriptions"] = self.descriptions
-        if self.service_codes:
-            params["serviceCodes"] = self.service_codes
-        if self.usage_types:
-            params["usageTypes"] = self.usage_types
-        if self.operations:
-            params["operations"] = self.operations
-        if self.filters:
-            params["filters"] = self.filters
-        if self.max_results:
-            params["maxResults"] = self.max_results
-        return params
+    offeringIds: Optional[List[str]] = None
+    paymentOptions: Optional[List[str]] = None
+    productType: Optional[str] = None
+    planTypes: Optional[List[str]] = None
+    durations: Optional[List[int]] = None
+    currencies: Optional[List[str]] = None
+    descriptions: Optional[List[str]] = None
+    serviceCodes: Optional[List[str]] = None
+    usageTypes: Optional[List[str]] = None
+    operations: Optional[str] = None
+    filters: Optional[List[Dict[str, Any]]] = None
+    nextToken: Optional[str] = None
+    maxResults: Optional[int] = 100

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,15 @@ version = 1
 requires-python = ">=3.13"
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643 },
+]
+
+[[package]]
 name = "boto3"
 version = "1.35.69"
 source = { registry = "https://pypi.org/simple" }
@@ -75,6 +84,7 @@ source = { editable = "." }
 dependencies = [
     { name = "boto3" },
     { name = "click" },
+    { name = "pydantic" },
     { name = "pytest" },
 ]
 
@@ -82,6 +92,7 @@ dependencies = [
 requires-dist = [
     { name = "boto3", specifier = ">=1.35.69" },
     { name = "click", specifier = ">=8.1.7" },
+    { name = "pydantic", specifier = ">=2.10.5" },
     { name = "pytest", specifier = ">=8.3.4" },
 ]
 
@@ -101,6 +112,45 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556 },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.10.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/c7/ca334c2ef6f2e046b1144fe4bb2a5da8a4c574e7f2ebf7e16b34a6a2fa92/pydantic-2.10.5.tar.gz", hash = "sha256:278b38dbbaec562011d659ee05f63346951b3a248a6f3642e1bc68894ea2b4ff", size = 761287 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/26/82663c79010b28eddf29dcdd0ea723439535fa917fce5905885c0e9ba562/pydantic-2.10.5-py3-none-any.whl", hash = "sha256:4dd4e322dbe55472cb7ca7e73f4b63574eecccf2835ffa2af9021ce113c83c53", size = 431426 },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.27.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/01/f3e5ac5e7c25833db5eb555f7b7ab24cd6f8c322d3a3ad2d67a952dc0abc/pydantic_core-2.27.2.tar.gz", hash = "sha256:eb026e5a4c1fee05726072337ff51d1efb6f59090b7da90d30ea58625b1ffb39", size = 413443 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/b1/9bc383f48f8002f99104e3acff6cba1231b29ef76cfa45d1506a5cad1f84/pydantic_core-2.27.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:7d14bd329640e63852364c306f4d23eb744e0f8193148d4044dd3dacdaacbd8b", size = 1892709 },
+    { url = "https://files.pythonhosted.org/packages/10/6c/e62b8657b834f3eb2961b49ec8e301eb99946245e70bf42c8817350cbefc/pydantic_core-2.27.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:82f91663004eb8ed30ff478d77c4d1179b3563df6cdb15c0817cd1cdaf34d154", size = 1811273 },
+    { url = "https://files.pythonhosted.org/packages/ba/15/52cfe49c8c986e081b863b102d6b859d9defc63446b642ccbbb3742bf371/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:71b24c7d61131bb83df10cc7e687433609963a944ccf45190cfc21e0887b08c9", size = 1823027 },
+    { url = "https://files.pythonhosted.org/packages/b1/1c/b6f402cfc18ec0024120602bdbcebc7bdd5b856528c013bd4d13865ca473/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fa8e459d4954f608fa26116118bb67f56b93b209c39b008277ace29937453dc9", size = 1868888 },
+    { url = "https://files.pythonhosted.org/packages/bd/7b/8cb75b66ac37bc2975a3b7de99f3c6f355fcc4d89820b61dffa8f1e81677/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ce8918cbebc8da707ba805b7fd0b382816858728ae7fe19a942080c24e5b7cd1", size = 2037738 },
+    { url = "https://files.pythonhosted.org/packages/c8/f1/786d8fe78970a06f61df22cba58e365ce304bf9b9f46cc71c8c424e0c334/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eda3f5c2a021bbc5d976107bb302e0131351c2ba54343f8a496dc8783d3d3a6a", size = 2685138 },
+    { url = "https://files.pythonhosted.org/packages/a6/74/d12b2cd841d8724dc8ffb13fc5cef86566a53ed358103150209ecd5d1999/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bd8086fa684c4775c27f03f062cbb9eaa6e17f064307e86b21b9e0abc9c0f02e", size = 1997025 },
+    { url = "https://files.pythonhosted.org/packages/a0/6e/940bcd631bc4d9a06c9539b51f070b66e8f370ed0933f392db6ff350d873/pydantic_core-2.27.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8d9b3388db186ba0c099a6d20f0604a44eabdeef1777ddd94786cdae158729e4", size = 2004633 },
+    { url = "https://files.pythonhosted.org/packages/50/cc/a46b34f1708d82498c227d5d80ce615b2dd502ddcfd8376fc14a36655af1/pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:7a66efda2387de898c8f38c0cf7f14fca0b51a8ef0b24bfea5849f1b3c95af27", size = 1999404 },
+    { url = "https://files.pythonhosted.org/packages/ca/2d/c365cfa930ed23bc58c41463bae347d1005537dc8db79e998af8ba28d35e/pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:18a101c168e4e092ab40dbc2503bdc0f62010e95d292b27827871dc85450d7ee", size = 2130130 },
+    { url = "https://files.pythonhosted.org/packages/f4/d7/eb64d015c350b7cdb371145b54d96c919d4db516817f31cd1c650cae3b21/pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ba5dd002f88b78a4215ed2f8ddbdf85e8513382820ba15ad5ad8955ce0ca19a1", size = 2157946 },
+    { url = "https://files.pythonhosted.org/packages/a4/99/bddde3ddde76c03b65dfd5a66ab436c4e58ffc42927d4ff1198ffbf96f5f/pydantic_core-2.27.2-cp313-cp313-win32.whl", hash = "sha256:1ebaf1d0481914d004a573394f4be3a7616334be70261007e47c2a6fe7e50130", size = 1834387 },
+    { url = "https://files.pythonhosted.org/packages/71/47/82b5e846e01b26ac6f1893d3c5f9f3a2eb6ba79be26eef0b759b4fe72946/pydantic_core-2.27.2-cp313-cp313-win_amd64.whl", hash = "sha256:953101387ecf2f5652883208769a79e48db18c6df442568a0b5ccd8c2723abee", size = 1990453 },
+    { url = "https://files.pythonhosted.org/packages/51/b2/b2b50d5ecf21acf870190ae5d093602d95f66c9c31f9d5de6062eb329ad1/pydantic_core-2.27.2-cp313-cp313-win_arm64.whl", hash = "sha256:ac4dbfd1691affb8f48c2c13241a2e3b60ff23247cbcf981759c768b6633cf8b", size = 1885186 },
 ]
 
 [[package]]
@@ -149,6 +199,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/71/39/171f1c67cd00715f190ba0b100d606d440a28c93c7714febeca8b79af85e/six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926", size = 34041 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254", size = 11053 },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.12.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8", size = 85321 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438 },
 ]
 
 [[package]]


### PR DESCRIPTION
dataclass から Pydantic へリプレイスしても動作する事を確認できたので Pydanticに置換して整理していく
https://docs.pydantic.dev/latest/api/base_model/

dataclass では null を避けて dict で取り出すのにひと手間必要だったが Pydantic であれば model_dump メソッドで nullの項目を無視してdict で取り出せたりして便利。jsonにも変換できるっぽい