### PR TITLE
fix: RDSManagerで複数offeringsが処理されないバグを修正

### DIFF
--- a/src/offering_finder/managers/rds_manager.py
+++ b/src/offering_finder/managers/rds_manager.py
@@ -61,7 +61,7 @@ class RDSManager:
                 logging.error(f"Value error: {e}")
             except Exception as e:
                 logging.error(f"An unexpected error occurred: {e}")
-            return result
+        return result
 
     def get_offerings(self, params: RDSParams) -> List[Dict[str, Any]]:
         try:

--- a/tests/test_rds_manager.py
+++ b/tests/test_rds_manager.py
@@ -1,0 +1,138 @@
+import pytest
+from src.offering_finder.managers.rds_manager import RDSManager
+from src.offering_finder.models.rds_params import RDSPurchaseParams
+
+
+def test_add_keys_to_offerings_single():
+    """単一のofferingが正しく処理されることを確認"""
+    manager = RDSManager(region_name="ap-northeast-1")
+    offerings = [
+        {
+            "ReservedDBInstancesOfferingId": "offering-id-123",
+            "FixedPrice": 100.0
+        }
+    ]
+    params = RDSPurchaseParams(
+        region_name="ap-northeast-1",
+        quantity=2,
+        reserved_instance_id=None
+    )
+    result = manager.add_keys_to_offerings(offerings, params)
+
+    assert len(result) == 1
+    assert result[0]["OrderQuantity"] == 2
+    assert result[0]["OrderEstimatedAmount"] == 200.0
+    assert "Timestamp" in result[0]
+    assert result[0]["PurchaseCommand"] == (
+        "aws rds purchase-reserved-db-instances-offering "
+        "--region ap-northeast-1 "
+        "--reserved-db-instances-offering-id offering-id-123 "
+        "--db-instance-count 2"
+    )
+
+
+def test_add_keys_to_offerings_multiple():
+    """複数のofferingsが全て処理されることを確認（バグ修正の確認）"""
+    manager = RDSManager(region_name="ap-northeast-1")
+    offerings = [
+        {
+            "ReservedDBInstancesOfferingId": "offering-id-1",
+            "FixedPrice": 100.0
+        },
+        {
+            "ReservedDBInstancesOfferingId": "offering-id-2",
+            "FixedPrice": 200.0
+        },
+        {
+            "ReservedDBInstancesOfferingId": "offering-id-3",
+            "FixedPrice": 300.0
+        }
+    ]
+    params = RDSPurchaseParams(
+        region_name="ap-northeast-1",
+        quantity=3,
+        reserved_instance_id=None
+    )
+    result = manager.add_keys_to_offerings(offerings, params)
+
+    # バグ修正前は1件しか返されなかったが、修正後は全て処理される
+    assert len(result) == 3
+
+    # 1件目の確認
+    assert result[0]["ReservedDBInstancesOfferingId"] == "offering-id-1"
+    assert result[0]["OrderQuantity"] == 3
+    assert result[0]["OrderEstimatedAmount"] == 300.0
+
+    # 2件目の確認
+    assert result[1]["ReservedDBInstancesOfferingId"] == "offering-id-2"
+    assert result[1]["OrderQuantity"] == 3
+    assert result[1]["OrderEstimatedAmount"] == 600.0
+
+    # 3件目の確認
+    assert result[2]["ReservedDBInstancesOfferingId"] == "offering-id-3"
+    assert result[2]["OrderQuantity"] == 3
+    assert result[2]["OrderEstimatedAmount"] == 900.0
+
+
+def test_add_keys_to_offerings_with_reserved_instance_id():
+    """reserved_instance_idが指定された場合に正しくコマンドに含まれることを確認"""
+    manager = RDSManager(region_name="ap-northeast-1")
+    offerings = [
+        {
+            "ReservedDBInstancesOfferingId": "offering-id-123",
+            "FixedPrice": 100.0
+        }
+    ]
+    params = RDSPurchaseParams(
+        region_name="ap-northeast-1",
+        quantity=2,
+        reserved_instance_id="my-reserved-instance"
+    )
+    result = manager.add_keys_to_offerings(offerings, params)
+
+    assert len(result) == 1
+    assert result[0]["PurchaseCommand"] == (
+        "aws rds purchase-reserved-db-instances-offering "
+        "--region ap-northeast-1 "
+        "--reserved-db-instances-offering-id offering-id-123 "
+        "--db-instance-count 2 "
+        "--reserved-db-instance-id my-reserved-instance"
+    )
+
+
+def test_add_keys_to_offerings_with_purchase_profile():
+    """purchase_profileが指定された場合に正しくコマンドに含まれることを確認"""
+    manager = RDSManager(region_name="ap-northeast-1")
+    offerings = [
+        {
+            "ReservedDBInstancesOfferingId": "offering-id-123",
+            "FixedPrice": 100.0
+        }
+    ]
+    params = RDSPurchaseParams(
+        purchase_profile="my-profile",
+        region_name="ap-northeast-1",
+        quantity=2,
+        reserved_instance_id=None
+    )
+    result = manager.add_keys_to_offerings(offerings, params)
+
+    assert len(result) == 1
+    assert result[0]["PurchaseCommand"].startswith("AWS_PROFILE=my-profile ")
+
+
+def test_add_keys_to_offerings_empty():
+    """空のリストを渡した場合に空のリストが返されることを確認"""
+    manager = RDSManager(region_name="ap-northeast-1")
+    offerings = []
+    params = RDSPurchaseParams(
+        region_name="ap-northeast-1",
+        quantity=1
+    )
+    result = manager.add_keys_to_offerings(offerings, params)
+
+    assert len(result) == 0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## 概要
`RDSManager.add_keys_to_offerings`メソッドで複数のofferingsが渡された場合に、最初の1件しか処理されない不具合を修正しました。

## 問題の詳細
- `add_keys_to_offerings`メソッド内の`return result`文がforループ内に配置されていた
- インデントの問題により、ループの最初の反復で必ずreturnしてしまっていた
- 結果として、複数のReserved Instance offeringsが見つかった場合でも1件しか返されなかった

## 修正内容
- `return result`文をforループの外に移動
- これにより全てのofferingsが正しく処理されるようになった

### 修正箇所
[src/offering_finder/managers/rds_manager.py:64](https://github.com/0xmks/offering_finder/blob/fix/rds-manager-return-bug/src/offering_finder/managers/rds_manager.py#L64)

```python
# 修正前（バグ）
for offering in offerings:
    try:
        # 処理...
    except Exception as e:
        logging.error(...)
    return result  # ← ループ内でreturn（バグ）

# 修正後
for offering in offerings:
    try:
        # 処理...
    except Exception as e:
        logging.error(...)
return result  # ← ループ完了後にreturn（正しい）
```

## テストについて
RDSManager用のユニットテストを新規作成し、以下をテストしています：

- ✅ 単一offering処理の正常動作
- ✅ **複数offerings処理の正常動作**（バグ修正の検証）
- ✅ reserved_instance_id指定時の動作
- ✅ purchase_profile指定時の動作
- ✅ 空リストの処理

全テストがパスしています。

## 影響範囲
- RDSのOffering検索で複数の結果が返される場合の動作が改善
- 既存の動作に破壊的変更はなし
- 他のManager（ElastiCache、SavingsPlans、OpenSearch）には影響なし

## チェックリスト
- [x] バグを修正
- [x] ユニットテストを追加
- [x] 全テストがパス
- [x] conventional commits形式でコミット

🤖 Generated with [Claude Code](https://claude.com/claude-code)