### PR TITLE
test: 全Managerのユニットテストを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,16 +152,10 @@ while True:
 
 ### 既知の問題・改善点
 
-#### 1. RDSManager のバグ ([rds_manager.py:64](src/offering_finder/managers/rds_manager.py#L64))
-```python
-def add_keys_to_offerings(self, offerings: Dict[str, Any], params: RDSPurchaseParams) -> Dict[str, Any]:
-    result = []
-    for offering in offerings:
-        # ... 処理 ...
-        return result  # ← ループの1回目でreturnしてしまう（インデントミス）
-```
-**問題**: ループ内でreturnしているため、最初の1件しか処理されない
-**修正方法**: returnをforループの外に出す
+#### 1. ~~RDSManager のバグ~~ ✅ 解決済み
+~~ループ内でreturnしているため、最初の1件しか処理されない問題~~
+
+**解決**: PR #4 ([0756509](https://github.com/0xmks/offering_finder/commit/0756509)) で修正済み
 
 #### 2. テストカバレッジ不足
 - RDS Manager: テストなし
@@ -177,7 +171,7 @@ def add_keys_to_offerings(self, offerings: Dict[str, Any], params: RDSPurchasePa
 ## 改善提案
 
 ### 優先度: 高
-1. **RDSManager.add_keys_to_offerings のバグ修正**
+1. ~~**RDSManager.add_keys_to_offerings のバグ修正**~~ ✅ 解決済み
 2. **全Managerのユニットテスト実装**
 3. **統合テストの追加**（モック使用）
 
@@ -223,4 +217,4 @@ def add_keys_to_offerings(self, offerings: Dict[str, Any], params: RDSPurchasePa
 Unlicense - パブリックドメイン
 
 ## 最終更新
-2025-01-17
+2025-01-30

--- a/tests/test_awsclient.py
+++ b/tests/test_awsclient.py
@@ -1,0 +1,144 @@
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from src.offering_finder.clients.AWSClient import AWSClient
+
+
+@patch("src.offering_finder.clients.AWSClient.boto3")
+def test_awsclient_init_rds(mock_boto3):
+    """RDSサービスのAWSClientが正しく初期化されることを確認"""
+    mock_client = Mock()
+    mock_boto3.client.return_value = mock_client
+
+    client = AWSClient("rds", "us-west-2")
+
+    mock_boto3.client.assert_called_once_with("rds", region_name="us-west-2")
+    assert client.client == mock_client
+
+
+@patch("src.offering_finder.clients.AWSClient.boto3")
+def test_awsclient_init_elasticache(mock_boto3):
+    """ElastiCacheサービスのAWSClientが正しく初期化されることを確認"""
+    mock_client = Mock()
+    mock_boto3.client.return_value = mock_client
+
+    client = AWSClient("elasticache", "us-west-2")
+
+    mock_boto3.client.assert_called_once_with("elasticache", region_name="us-west-2")
+    assert client.client == mock_client
+
+
+@patch("src.offering_finder.clients.AWSClient.boto3")
+def test_describe_offerings_rds(mock_boto3):
+    """RDSのdescribe_offeringsが正しく呼ばれることを確認"""
+    mock_client = Mock()
+    mock_client.meta.service_model.service_name = "rds"
+    mock_client.describe_reserved_db_instances_offerings.return_value = {
+        "ReservedDBInstancesOfferings": [{"OfferingId": "rds-123"}]
+    }
+    mock_boto3.client.return_value = mock_client
+
+    client = AWSClient("rds", "us-west-2")
+    result = client.describe_offerings({"ProductDescription": "MySQL"})
+
+    mock_client.describe_reserved_db_instances_offerings.assert_called_once_with(
+        ProductDescription="MySQL"
+    )
+    assert result == {"ReservedDBInstancesOfferings": [{"OfferingId": "rds-123"}]}
+
+
+@patch("src.offering_finder.clients.AWSClient.boto3")
+def test_describe_offerings_elasticache(mock_boto3):
+    """ElastiCacheのdescribe_offeringsが正しく呼ばれることを確認"""
+    mock_client = Mock()
+    mock_client.meta.service_model.service_name = "elasticache"
+    mock_client.describe_reserved_cache_nodes_offerings.return_value = {
+        "ReservedCacheNodesOfferings": [{"OfferingId": "ec-123"}]
+    }
+    mock_boto3.client.return_value = mock_client
+
+    client = AWSClient("elasticache", "us-west-2")
+    result = client.describe_offerings({"ProductDescription": "redis"})
+
+    mock_client.describe_reserved_cache_nodes_offerings.assert_called_once_with(
+        ProductDescription="redis"
+    )
+    assert result == {"ReservedCacheNodesOfferings": [{"OfferingId": "ec-123"}]}
+
+
+@patch("src.offering_finder.clients.AWSClient.boto3")
+def test_describe_offerings_savingsplans(mock_boto3):
+    """Savings Plansのdescribe_offeringsが正しく呼ばれることを確認"""
+    mock_client = Mock()
+    mock_client.meta.service_model.service_name = "savingsplans"
+    mock_client.describe_savings_plans_offerings.return_value = {
+        "searchResults": [{"offeringId": "sp-123"}]
+    }
+    mock_boto3.client.return_value = mock_client
+
+    client = AWSClient("savingsplans", "us-west-2")
+    result = client.describe_offerings({"productType": "EC2"})
+
+    mock_client.describe_savings_plans_offerings.assert_called_once_with(
+        productType="EC2"
+    )
+    assert result == {"searchResults": [{"offeringId": "sp-123"}]}
+
+
+@patch("src.offering_finder.clients.AWSClient.boto3")
+def test_describe_offerings_opensearch(mock_boto3):
+    """OpenSearchのdescribe_offeringsが正しく呼ばれることを確認"""
+    mock_client = Mock()
+    mock_client.meta.service_model.service_name = "opensearch"
+    mock_client.describe_reserved_instance_offerings.return_value = {
+        "ReservedInstanceOfferings": [{"OfferingId": "os-123"}]
+    }
+    mock_boto3.client.return_value = mock_client
+
+    client = AWSClient("opensearch", "us-west-2")
+    result = client.describe_offerings({"MaxResults": 100})
+
+    mock_client.describe_reserved_instance_offerings.assert_called_once_with(
+        MaxResults=100
+    )
+    assert result == {"ReservedInstanceOfferings": [{"OfferingId": "os-123"}]}
+
+
+@patch("src.offering_finder.clients.AWSClient.boto3")
+def test_describe_offerings_unsupported_service(mock_boto3):
+    """未サポートのサービスでValueErrorが発生することを確認"""
+    mock_client = Mock()
+    mock_client.meta.service_model.service_name = "s3"
+    mock_boto3.client.return_value = mock_client
+
+    client = AWSClient("s3", "us-west-2")
+
+    with pytest.raises(ValueError, match="Unsupported service"):
+        client.describe_offerings({})
+
+
+@patch("src.offering_finder.clients.AWSClient.boto3")
+def test_describe_offerings_with_multiple_params(mock_boto3):
+    """複数のパラメータが正しく渡されることを確認"""
+    mock_client = Mock()
+    mock_client.meta.service_model.service_name = "rds"
+    mock_client.describe_reserved_db_instances_offerings.return_value = {
+        "ReservedDBInstancesOfferings": []
+    }
+    mock_boto3.client.return_value = mock_client
+
+    client = AWSClient("rds", "us-west-2")
+    params = {
+        "ProductDescription": "MySQL",
+        "DBInstanceClass": "db.m5.large",
+        "Duration": "31536000",
+        "OfferingType": "All Upfront",
+    }
+    result = client.describe_offerings(params)
+
+    mock_client.describe_reserved_db_instances_offerings.assert_called_once_with(
+        **params
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_elasticache_manager.py
+++ b/tests/test_elasticache_manager.py
@@ -1,23 +1,26 @@
 import pytest
 from src.offering_finder.managers.elasticache_manager import ElastiCacheManager
-from src.offering_finder.models.elasticache_params import ElastiCacheParams
+from src.offering_finder.models.elasticache_params import ElastiCachePurchaseParams
 
 def test_add_keys_to_offering_success():
     manager = ElastiCacheManager(region_name="us-west-2")
-    offering = {
-        "ReservedCacheNodesOfferingId": "offering-id-123",
-        "FixedPrice": "100.0"
-    }
-    params = ElastiCacheParams(
+    offerings = [
+        {
+            "ReservedCacheNodesOfferingId": "offering-id-123",
+            "FixedPrice": 100.0
+        }
+    ]
+    params = ElastiCachePurchaseParams(
         region_name="us-west-2",
         quantity=2,
         reserved_cache_node_id=None
     )
-    updated_offering = manager.add_keys_to_offering(offering, params)
-    assert updated_offering["OrderQuantity"] == 2
-    assert updated_offering["OrderEstimatedAmount"] == 200.0
-    assert "Timestamp" in updated_offering
-    assert updated_offering["PurchaseCommand"] == (
+    result = manager.add_keys_to_offerings(offerings, params)
+    assert len(result) == 1
+    assert result[0]["OrderQuantity"] == 2
+    assert result[0]["OrderEstimatedAmount"] == 200.0
+    assert "Timestamp" in result[0]
+    assert result[0]["PurchaseCommand"] == (
         "aws elasticache purchase-reserved-cache-nodes-offering "
         "--region us-west-2 "
         "--reserved-cache-nodes-offering-id offering-id-123 "
@@ -26,20 +29,23 @@ def test_add_keys_to_offering_success():
 
 def test_add_keys_to_offering_with_reserved_cache_node_id():
     manager = ElastiCacheManager(region_name="us-west-2")
-    offering = {
-        "ReservedCacheNodesOfferingId": "offering-id-123",
-        "FixedPrice": "100.0"
-    }
-    params = ElastiCacheParams(
+    offerings = [
+        {
+            "ReservedCacheNodesOfferingId": "offering-id-123",
+            "FixedPrice": 100.0
+        }
+    ]
+    params = ElastiCachePurchaseParams(
         region_name="us-west-2",
         quantity=2,
         reserved_cache_node_id="node-id-123"
     )
-    updated_offering = manager.add_keys_to_offering(offering, params)
-    assert updated_offering["OrderQuantity"] == 2
-    assert updated_offering["OrderEstimatedAmount"] == 200.0
-    assert "Timestamp" in updated_offering
-    assert updated_offering["PurchaseCommand"] == (
+    result = manager.add_keys_to_offerings(offerings, params)
+    assert len(result) == 1
+    assert result[0]["OrderQuantity"] == 2
+    assert result[0]["OrderEstimatedAmount"] == 200.0
+    assert "Timestamp" in result[0]
+    assert result[0]["PurchaseCommand"] == (
         "aws elasticache purchase-reserved-cache-nodes-offering "
         "--region us-west-2 "
         "--reserved-cache-nodes-offering-id offering-id-123 "

--- a/tests/test_opensearch_manager.py
+++ b/tests/test_opensearch_manager.py
@@ -1,0 +1,250 @@
+import pytest
+from src.offering_finder.managers.opensearch_manager import OpenSearchManager
+from src.offering_finder.models.opensearch_params import (
+    OpenSearchPurchaseParams,
+    OpenSearchFilterParams,
+)
+
+
+def test_add_keys_to_offerings_single():
+    """単一のofferingが正しく処理されることを確認"""
+    manager = OpenSearchManager(region_name="us-west-2")
+    offerings = [
+        {
+            "ReservedInstanceOfferingId": "offering-id-123",
+            "FixedPrice": 100.0,
+        }
+    ]
+    params = OpenSearchPurchaseParams(
+        region_name="us-west-2",
+        quantity=2,
+    )
+    result = manager.add_keys_to_offerings(offerings, params)
+
+    assert len(result) == 1
+    assert result[0]["OrderQuantity"] == 2
+    assert result[0]["OrderEstimatedAmount"] == 200.0
+    assert "Timestamp" in result[0]
+    assert result[0]["PurchaseCommand"] == (
+        "aws opensearch purchase-reserved-instance-offering "
+        "--reserved-instance-offering-id offering-id-123 "
+        "--instance-count 2 "
+        "--region us-west-2"
+    )
+
+
+def test_add_keys_to_offerings_multiple():
+    """複数のofferingsが全て処理されることを確認"""
+    manager = OpenSearchManager(region_name="us-west-2")
+    offerings = [
+        {
+            "ReservedInstanceOfferingId": "offering-id-1",
+            "FixedPrice": 100.0,
+        },
+        {
+            "ReservedInstanceOfferingId": "offering-id-2",
+            "FixedPrice": 200.0,
+        },
+        {
+            "ReservedInstanceOfferingId": "offering-id-3",
+            "FixedPrice": 300.0,
+        },
+    ]
+    params = OpenSearchPurchaseParams(
+        region_name="us-west-2",
+        quantity=3,
+    )
+    result = manager.add_keys_to_offerings(offerings, params)
+
+    assert len(result) == 3
+
+    # 1件目の確認
+    assert result[0]["ReservedInstanceOfferingId"] == "offering-id-1"
+    assert result[0]["OrderQuantity"] == 3
+    assert result[0]["OrderEstimatedAmount"] == 300.0
+
+    # 2件目の確認
+    assert result[1]["ReservedInstanceOfferingId"] == "offering-id-2"
+    assert result[1]["OrderQuantity"] == 3
+    assert result[1]["OrderEstimatedAmount"] == 600.0
+
+    # 3件目の確認
+    assert result[2]["ReservedInstanceOfferingId"] == "offering-id-3"
+    assert result[2]["OrderQuantity"] == 3
+    assert result[2]["OrderEstimatedAmount"] == 900.0
+
+
+def test_add_keys_to_offerings_with_reservation_name():
+    """reservation_nameが指定された場合に正しくコマンドに含まれることを確認"""
+    manager = OpenSearchManager(region_name="us-west-2")
+    offerings = [
+        {
+            "ReservedInstanceOfferingId": "offering-id-123",
+            "FixedPrice": 100.0,
+        }
+    ]
+    params = OpenSearchPurchaseParams(
+        region_name="us-west-2",
+        quantity=2,
+        reservation_name="my-reservation",
+    )
+    result = manager.add_keys_to_offerings(offerings, params)
+
+    assert len(result) == 1
+    assert result[0]["PurchaseCommand"] == (
+        "aws opensearch purchase-reserved-instance-offering "
+        "--reserved-instance-offering-id offering-id-123 "
+        "--instance-count 2 "
+        "--region us-west-2 "
+        "--reservation-name my-reservation"
+    )
+
+
+def test_add_keys_to_offerings_with_purchase_profile():
+    """purchase_profileが指定された場合に正しくコマンドに含まれることを確認"""
+    manager = OpenSearchManager(region_name="us-west-2")
+    offerings = [
+        {
+            "ReservedInstanceOfferingId": "offering-id-123",
+            "FixedPrice": 100.0,
+        }
+    ]
+    params = OpenSearchPurchaseParams(
+        purchase_profile="my-profile",
+        region_name="us-west-2",
+        quantity=2,
+    )
+    result = manager.add_keys_to_offerings(offerings, params)
+
+    assert len(result) == 1
+    assert result[0]["PurchaseCommand"].startswith("AWS_PROFILE=my-profile ")
+
+
+def test_add_keys_to_offerings_empty():
+    """空のリストを渡した場合に空のリストが返されることを確認"""
+    manager = OpenSearchManager(region_name="us-west-2")
+    offerings = []
+    params = OpenSearchPurchaseParams(
+        region_name="us-west-2",
+        quantity=1,
+    )
+    result = manager.add_keys_to_offerings(offerings, params)
+
+    assert len(result) == 0
+
+
+def test_filter_offerings_match_all():
+    """全ての条件に一致するofferingが正しくフィルタリングされることを確認"""
+    manager = OpenSearchManager(region_name="us-west-2")
+    offerings = [
+        {
+            "ReservedInstanceOfferingId": "offering-1",
+            "InstanceType": "m5.large",
+            "Duration": 31536000,
+            "CurrencyCode": "USD",
+            "PaymentOption": "ALL_UPFRONT",
+        },
+        {
+            "ReservedInstanceOfferingId": "offering-2",
+            "InstanceType": "m5.xlarge",
+            "Duration": 31536000,
+            "CurrencyCode": "USD",
+            "PaymentOption": "ALL_UPFRONT",
+        },
+    ]
+    filter_params = OpenSearchFilterParams(
+        InstanceType="m5.large",
+        Duration=31536000,
+        CurrencyCode="USD",
+        PaymentOption="ALL_UPFRONT",
+    )
+    result = manager.filter_offerings(offerings, filter_params)
+
+    assert len(result) == 1
+    assert result[0]["ReservedInstanceOfferingId"] == "offering-1"
+
+
+def test_filter_offerings_no_match():
+    """条件に一致しないofferingがフィルタリングされることを確認"""
+    manager = OpenSearchManager(region_name="us-west-2")
+    offerings = [
+        {
+            "ReservedInstanceOfferingId": "offering-1",
+            "InstanceType": "m5.large",
+            "Duration": 31536000,
+            "CurrencyCode": "USD",
+            "PaymentOption": "ALL_UPFRONT",
+        },
+    ]
+    filter_params = OpenSearchFilterParams(
+        InstanceType="m5.xlarge",  # 一致しない
+    )
+    result = manager.filter_offerings(offerings, filter_params)
+
+    assert len(result) == 0
+
+
+def test_filter_offerings_partial_match():
+    """一部の条件のみ指定した場合に正しくフィルタリングされることを確認"""
+    manager = OpenSearchManager(region_name="us-west-2")
+    offerings = [
+        {
+            "ReservedInstanceOfferingId": "offering-1",
+            "InstanceType": "m5.large",
+            "Duration": 31536000,
+            "CurrencyCode": "USD",
+            "PaymentOption": "ALL_UPFRONT",
+        },
+        {
+            "ReservedInstanceOfferingId": "offering-2",
+            "InstanceType": "m5.large",
+            "Duration": 31536000,  # デフォルト値と同じにする
+            "CurrencyCode": "USD",
+            "PaymentOption": "NO_UPFRONT",
+        },
+    ]
+    filter_params = OpenSearchFilterParams(
+        InstanceType="m5.large",
+        # Duration と CurrencyCode はデフォルト値を使用
+        # PaymentOption は None
+    )
+    result = manager.filter_offerings(offerings, filter_params)
+
+    # m5.large で Duration が 31536000 (デフォルト), CurrencyCode が USD (デフォルト) の両方が一致
+    assert len(result) == 2
+
+
+def test_generate_purchase_command():
+    """purchase commandの生成が正しく行われることを確認"""
+    manager = OpenSearchManager(region_name="us-west-2")
+
+    # 最小限のパラメータ
+    command = manager.generate_purchase_command(
+        offering_id="offering-123",
+        region_name="us-west-2",
+        quantity=2,
+    )
+    assert command == (
+        "aws opensearch purchase-reserved-instance-offering "
+        "--reserved-instance-offering-id offering-123 "
+        "--instance-count 2 "
+        "--region us-west-2"
+    )
+
+    # 全パラメータ指定
+    command = manager.generate_purchase_command(
+        offering_id="offering-123",
+        region_name="us-west-2",
+        quantity=2,
+        reservation_name="my-reservation",
+        purchase_profile="my-profile",
+    )
+    assert command.startswith("AWS_PROFILE=my-profile ")
+    assert "--reserved-instance-offering-id offering-123" in command
+    assert "--instance-count 2" in command
+    assert "--region us-west-2" in command
+    assert "--reservation-name my-reservation" in command
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_savingsplans_manager.py
+++ b/tests/test_savingsplans_manager.py
@@ -1,0 +1,183 @@
+import pytest
+from src.offering_finder.managers.savingsplans_manager import SavingsPlansManager
+from src.offering_finder.models.savingsplans_params import SavingsPlansPurchaseParams
+
+
+def test_add_keys_to_offerings_single():
+    """単一のofferingが正しく処理されることを確認"""
+    manager = SavingsPlansManager(region_name="us-west-2")
+    offerings = [
+        {
+            "offeringId": "sp-offering-123",
+            "durationSeconds": 31536000,  # 1年 = 8760時間
+        }
+    ]
+    params = SavingsPlansPurchaseParams(
+        region_name="us-west-2",
+        commitment=10.0,
+    )
+    result = manager.add_keys_to_offerings(offerings, params)
+
+    assert len(result) == 1
+    assert result[0]["OrderCommitment"] == 10.0
+    # 31536000秒 = 8760時間、8760 * 10.0 = 87600.0
+    assert result[0]["OrderEstimatedAmount"] == 87600.0
+    assert "Timestamp" in result[0]
+    assert result[0]["PurchaseCommand"] == (
+        "aws savingsplans create-savings-plan "
+        "--region us-west-2 "
+        "--savings-plan-offering-id sp-offering-123 "
+        "--commitment 10.0"
+    )
+
+
+def test_add_keys_to_offerings_multiple():
+    """複数のofferingsが全て処理されることを確認"""
+    manager = SavingsPlansManager(region_name="us-west-2")
+    offerings = [
+        {
+            "offeringId": "sp-offering-1",
+            "durationSeconds": 31536000,
+        },
+        {
+            "offeringId": "sp-offering-2",
+            "durationSeconds": 94608000,  # 3年
+        },
+    ]
+    params = SavingsPlansPurchaseParams(
+        region_name="us-west-2",
+        commitment=5.0,
+    )
+    result = manager.add_keys_to_offerings(offerings, params)
+
+    assert len(result) == 2
+
+    # 1件目の確認
+    assert result[0]["offeringId"] == "sp-offering-1"
+    assert result[0]["OrderCommitment"] == 5.0
+    assert result[0]["OrderEstimatedAmount"] == 43800.0  # 8760 * 5.0
+
+    # 2件目の確認
+    assert result[1]["offeringId"] == "sp-offering-2"
+    assert result[1]["OrderCommitment"] == 5.0
+    assert result[1]["OrderEstimatedAmount"] == 131400.0  # 26280 * 5.0
+
+
+def test_add_keys_to_offerings_with_purchase_profile():
+    """purchase_profileが指定された場合に正しくコマンドに含まれることを確認"""
+    manager = SavingsPlansManager(region_name="us-west-2")
+    offerings = [
+        {
+            "offeringId": "sp-offering-123",
+            "durationSeconds": 31536000,
+        }
+    ]
+    params = SavingsPlansPurchaseParams(
+        purchase_profile="my-profile",
+        region_name="us-west-2",
+        commitment=10.0,
+    )
+    result = manager.add_keys_to_offerings(offerings, params)
+
+    assert len(result) == 1
+    assert result[0]["PurchaseCommand"].startswith("AWS_PROFILE=my-profile ")
+
+
+def test_add_keys_to_offerings_with_optional_params():
+    """オプションパラメータ（purchase_time, client_token）が正しくコマンドに含まれることを確認"""
+    manager = SavingsPlansManager(region_name="us-west-2")
+    offerings = [
+        {
+            "offeringId": "sp-offering-123",
+            "durationSeconds": 31536000,
+        }
+    ]
+    params = SavingsPlansPurchaseParams(
+        region_name="us-west-2",
+        commitment=10.0,
+        purchase_time="2025-01-30T00:00:00Z",
+        client_token="my-client-token",
+    )
+    result = manager.add_keys_to_offerings(offerings, params)
+
+    assert len(result) == 1
+    assert "--purchase-time 2025-01-30T00:00:00Z" in result[0]["PurchaseCommand"]
+    assert "--client-token my-client-token" in result[0]["PurchaseCommand"]
+
+
+def test_add_keys_to_offerings_with_tags():
+    """タグが指定された場合に正しくコマンドに含まれることを確認"""
+    manager = SavingsPlansManager(region_name="us-west-2")
+    offerings = [
+        {
+            "offeringId": "sp-offering-123",
+            "durationSeconds": 31536000,
+        }
+    ]
+    params = SavingsPlansPurchaseParams(
+        region_name="us-west-2",
+        commitment=10.0,
+        tags=[
+            {"Key": "Environment", "Value": "Production"},
+            {"Key": "Team", "Value": "DevOps"},
+        ],
+    )
+    result = manager.add_keys_to_offerings(offerings, params)
+
+    assert len(result) == 1
+    assert "--tags Key=Environment,Value=Production" in result[0]["PurchaseCommand"]
+    assert "--tags Key=Team,Value=DevOps" in result[0]["PurchaseCommand"]
+
+
+def test_add_keys_to_offerings_empty():
+    """空のリストを渡した場合に空のリストが返されることを確認"""
+    manager = SavingsPlansManager(region_name="us-west-2")
+    offerings = []
+    params = SavingsPlansPurchaseParams(
+        region_name="us-west-2",
+        commitment=10.0,
+    )
+    result = manager.add_keys_to_offerings(offerings, params)
+
+    assert len(result) == 0
+
+
+def test_generate_purchase_command():
+    """purchase commandの生成が正しく行われることを確認"""
+    manager = SavingsPlansManager(region_name="us-west-2")
+
+    # 最小限のパラメータ
+    command = manager.generate_purchase_command(
+        purchase_profile=None,
+        region_name="us-west-2",
+        offering_id="sp-offering-123",
+        commitment=10,
+    )
+    assert command == (
+        "aws savingsplans create-savings-plan "
+        "--region us-west-2 "
+        "--savings-plan-offering-id sp-offering-123 "
+        "--commitment 10"
+    )
+
+    # 全パラメータ指定
+    command = manager.generate_purchase_command(
+        purchase_profile="my-profile",
+        region_name="us-west-2",
+        offering_id="sp-offering-123",
+        commitment=10,
+        purchase_time="2025-01-30T00:00:00Z",
+        client_token="token-123",
+        tags=[{"Key": "Env", "Value": "Prod"}],
+    )
+    assert command.startswith("AWS_PROFILE=my-profile ")
+    assert "--region us-west-2" in command
+    assert "--savings-plan-offering-id sp-offering-123" in command
+    assert "--commitment 10" in command
+    assert "--purchase-time 2025-01-30T00:00:00Z" in command
+    assert "--client-token token-123" in command
+    assert "--tags Key=Env,Value=Prod" in command
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## 概要
CLAUDE.mdの改善提案「優先度: 高 - 全Managerのユニットテスト実装」に対応し、テストカバレッジを大幅に向上させました。

## 変更内容

### 新規作成したテストファイル

#### 1. `tests/test_savingsplans_manager.py` (新規)
- `add_keys_to_offerings` メソッドのテスト
- `generate_purchase_command` メソッドのテスト
- オプションパラメータのテスト
  - `purchase_time`
  - `client_token`
  - `tags`
- 複数offerings処理のテスト
- 空配列のエッジケース

#### 2. `tests/test_opensearch_manager.py` (新規)
- `add_keys_to_offerings` メソッドのテスト
- `filter_offerings` メソッドのテスト
- `generate_purchase_command` メソッドのテスト
- `reservation_name` パラメータのテスト
- フィルタリングロジックのテスト（完全一致、部分一致、不一致）

#### 3. `tests/test_awsclient.py` (新規)
- 各サービス（RDS, ElastiCache, Savings Plans, OpenSearch）の初期化テスト
- `describe_offerings` メソッドのサービス別テスト（モック使用）
- 未サポートサービスのエラーハンドリングテスト
- 複数パラメータ渡しのテスト

### 修正したテストファイル

#### 4. `tests/test_elasticache_manager.py` (修正)
- ❌ 間違い: `ElastiCacheParams` を使用
- ✅ 修正: `ElastiCachePurchaseParams` に変更
- ❌ 間違い: メソッド名 `add_keys_to_offering` (単数形)
- ✅ 修正: `add_keys_to_offerings` (複数形) に変更
- ❌ 間違い: `FixedPrice` を文字列 `"100.0"` で設定
- ✅ 修正: 数値 `100.0` に変更（AWS API仕様に準拠）

## テスト結果

```
============================== 31 passed in 5.83s ==============================
```

- ✅ 全31テストがパス
- ✅ AWS公式ドキュメントに基づくデータ型を使用
- ✅ エッジケースをカバー（空配列、複数レコード、エラーハンドリング）

## テストカバレッジ改善

### Before（変更前）
- ✅ ElastiCache Manager: テストあり（ただし不完全）
- ❌ RDS Manager: テストなし
- ❌ Savings Plans Manager: テストなし
- ❌ OpenSearch Manager: テストなし
- ❌ AWSClient: テストなし

### After（変更後）
- ✅ ElastiCache Manager: テストあり（修正済み）
- ✅ RDS Manager: テストあり（既存）
- ✅ Savings Plans Manager: **テスト追加**
- ✅ OpenSearch Manager: **テスト追加**
- ✅ AWSClient: **テスト追加**

## 関連ISSUE

CLAUDE.md「優先度: 高」の改善提案:
- ~~1. RDSManager.add_keys_to_offeringsのバグ修正~~ ✅ 解決済み（PR #4）
- **2. 全Managerのユニットテスト実装** ← このPR
- 3. 統合テストの追加（次のPRで対応予定）

## チェックリスト

- [x] 全テストがパス
- [x] AWS公式ドキュメントに基づくテストデータを使用
- [x] 既存のテストを修正（ElastiCache）
- [x] 新規テストを追加（Savings Plans, OpenSearch, AWSClient）
- [x] エッジケースをカバー
- [x] モックを使用してAWS APIに依存しないテスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)