### PR TITLE
docs: CLAUDE.mdを更新してテストカバレッジ改善を反映

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,8 +147,12 @@ while True:
 - ✅ AWSClient 統一ラッパー
 
 ### テスト状況
+- ✅ RDS Manager のテストコードあり (`test_rds_manager.py`)
 - ✅ ElastiCache Manager のテストコードあり (`test_elasticache_manager.py`)
-- ⚠️ 他のマネージャーのテストコードは未実装
+- ✅ Savings Plans Manager のテストコードあり (`test_savingsplans_manager.py`)
+- ✅ OpenSearch Manager のテストコードあり (`test_opensearch_manager.py`)
+- ✅ AWSClient のテストコードあり (`test_awsclient.py`)
+- ✅ 全31テストがパス
 
 ### 既知の問題・改善点
 
@@ -157,11 +161,13 @@ while True:
 
 **解決**: PR #4 ([0756509](https://github.com/0xmks/offering_finder/commit/0756509)) で修正済み
 
-#### 2. テストカバレッジ不足
-- RDS Manager: テストなし
-- Savings Plans Manager: テストなし
-- OpenSearch Manager: テストなし
-- AWSClient: テストなし
+#### 2. ~~テストカバレッジ不足~~ ✅ 解決済み
+~~RDS Manager、Savings Plans Manager、OpenSearch Manager、AWSClientのテストが未実装~~
+
+**解決**: PR #5 ([976ac07](https://github.com/0xmks/offering_finder/commit/976ac07)) で全Managerのユニットテストを追加
+- 全31テストがパス
+- AWS公式ドキュメントに基づくテストデータを使用
+- モックを使用してAWS APIに依存しないテスト
 
 #### 3. エラーハンドリング
 - 現状はログ出力のみ
@@ -172,7 +178,7 @@ while True:
 
 ### 優先度: 高
 1. ~~**RDSManager.add_keys_to_offerings のバグ修正**~~ ✅ 解決済み
-2. **全Managerのユニットテスト実装**
+2. ~~**全Managerのユニットテスト実装**~~ ✅ 解決済み
 3. **統合テストの追加**（モック使用）
 
 ### 優先度: 中


### PR DESCRIPTION
## 概要
PR #5で全Managerのユニットテストが実装されたため、CLAUDE.mdを更新して最新の状態を反映しました。

## 変更内容

### 1. テスト状況セクションの更新

**Before:**
```markdown
### テスト状況
- ✅ ElastiCache Manager のテストコードあり (`test_elasticache_manager.py`)
- ⚠️ 他のマネージャーのテストコードは未実装
```

**After:**
```markdown
### テスト状況
- ✅ RDS Manager のテストコードあり (`test_rds_manager.py`)
- ✅ ElastiCache Manager のテストコードあり (`test_elasticache_manager.py`)
- ✅ Savings Plans Manager のテストコードあり (`test_savingsplans_manager.py`)
- ✅ OpenSearch Manager のテストコードあり (`test_opensearch_manager.py`)
- ✅ AWSClient のテストコードあり (`test_awsclient.py`)
- ✅ 全31テストがパス
```

### 2. 既知の問題セクションの更新

**Before:**
```markdown
#### 2. テストカバレッジ不足
- RDS Manager: テストなし
- Savings Plans Manager: テストなし
- OpenSearch Manager: テストなし
- AWSClient: テストなし
```

**After:**
```markdown
#### 2. ~~テストカバレッジ不足~~ ✅ 解決済み
~~RDS Manager、Savings Plans Manager、OpenSearch Manager、AWSClientのテストが未実装~~

**解決**: PR #5 ([976ac07](https://github.com/0xmks/offering_finder/commit/976ac07)) で全Managerのユニットテストを追加
- 全31テストがパス
- AWS公式ドキュメントに基づくテストデータを使用
- モックを使用してAWS APIに依存しないテスト
```

### 3. 改善提案セクションの更新

**Before:**
```markdown
### 優先度: 高
1. ~~**RDSManager.add_keys_to_offerings のバグ修正**~~ ✅ 解決済み
2. **全Managerのユニットテスト実装**
3. **統合テストの追加**（モック使用）
```

**After:**
```markdown
### 優先度: 高
1. ~~**RDSManager.add_keys_to_offerings のバグ修正**~~ ✅ 解決済み
2. ~~**全Managerのユニットテスト実装**~~ ✅ 解決済み
3. **統合テストの追加**（モック使用）
```

## 解決済みタスクのサマリー

### 優先度: 高（3項目中2項目完了）
- ✅ RDSManagerのバグ修正（PR #4）
- ✅ 全Managerのユニットテスト実装（PR #5）
- ⏳ 統合テストの追加（次のタスク）

## 関連PR

- #4: RDSManagerのバグ修正
- #5: 全Managerのユニットテスト追加
- #6: CLAUDE.md更新（RDSManagerバグ）

## チェックリスト

- [x] テスト状況を正確に反映
- [x] 解決済み問題を明確にマーク
- [x] PR参照リンクを追加
- [x] 改善提案リストを更新
- [x] マークダウンの書式が正しい

🤖 Generated with [Claude Code](https://claude.com/claude-code)